### PR TITLE
remove microdependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,6 @@ var errorEx = function errorEx(name, properties) {
 			configurable: true,
 			enumerable: false,
 			get: function () {
-				var newMessage = message.split(/\r?\n/g);
-
 				for (var key in properties) {
 					if (!properties.hasOwnProperty(key)) {
 						continue;
@@ -35,15 +33,16 @@ var errorEx = function errorEx(name, properties) {
 
 					var modifier = properties[key];
 
-					if ('message' in modifier) {
-						newMessage = modifier.message(this[key], newMessage) || newMessage;
-						if (!Array.isArray(newMessage)) {
-							newMessage = [newMessage];
+					if (modifier.message) {
+						var splitMessage = message.split(/\r?\n/g);
+						var modifiedMessage = modifier.message(this[key], splitMessage);
+						if (modifiedMessage) {
+							return modifiedMessage;
 						}
 					}
 				}
 
-				return newMessage.join('\n');
+				return message;
 			},
 			set: function (v) {
 				message = v;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var util = require('util');
-var isArrayish = require('is-arrayish');
 
 var errorEx = function errorEx(name, properties) {
 	if (!name || name.constructor !== String) {
@@ -38,7 +37,7 @@ var errorEx = function errorEx(name, properties) {
 
 					if ('message' in modifier) {
 						newMessage = modifier.message(this[key], newMessage) || newMessage;
-						if (!isArrayish(newMessage)) {
+						if (!Array.isArray(newMessage)) {
 							newMessage = [newMessage];
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,5 @@
     "should": "^7.0.1",
     "xo": "^0.7.1"
   },
-  "dependencies": {
-    "is-arrayish": "^0.2.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
You really don't need this micro-dependency, `Array.isArray` will do just fine for your use case here.

One less dependency, and now zero-dependencies overall.

im aware you were trying to remove array support a few years back but that didn't seem to go anywhere. this package is still widely used so would be nice to strip one more unnecessary bit of cruft from the dependency tree regardless.